### PR TITLE
Add --no-record option

### DIFF
--- a/xscast.1
+++ b/xscast.1
@@ -44,7 +44,7 @@ Do not display the bar containing keystrokes.
 Set a delay before starting to record.
 .TP
 .BR \-R ", " \-\-no-record
-Do not record, only display the bar containing keystrokes
+Do not record, only display the bar containing keystrokes.
 .SH FILES
 .TP
 .I ~/.xscastrc

--- a/xscast.1
+++ b/xscast.1
@@ -42,6 +42,9 @@ Do not display the bar containing keystrokes.
 .TP
 .BR \-d ", " \-\-delay
 Set a delay before starting to record.
+.TP
+.BR \-R ", " \-\-no-record
+Do not record, only display the bar containing keystrokes
 .SH FILES
 .TP
 .I ~/.xscastrc

--- a/xscast.sh
+++ b/xscast.sh
@@ -267,5 +267,6 @@ then
   ( ffmpeg -video_size ${ww}x$wh -framerate 25 -f x11grab -i :0.0+$wx,$wy \
       -f image2pipe -vcodec ppm - & echo $! >&3 ) 3>>.xscastpid | \
       convert -delay 4 -loop 0 - "$outfile"
-  rm .xscastpid
 fi
+wait
+rm .xscastpid

--- a/xscast.sh
+++ b/xscast.sh
@@ -130,12 +130,14 @@ dbar="${c_dbar:-$dbar}"
 drecord="${c_drecord:-$drecord}"
 delay="${c_delay:-$delay}"
 
-if [[ "$drecord" == yes && -z "$outfile" ]]; then
+if [ "$drecord" == yes ] && [ -z "$outfile" ]
+then
   echo >&2 Missing output file
   exit 1
 fi
 
-if [[ "$drecord" == no && "$dbar" == no ]]; then
+if [ "$drecord" == no ] && [ "$dbar" == no ]
+then
   echo >&2 "The options --no-bar and --no-record are mutually exclusive"
   exit 1
 fi


### PR DESCRIPTION
Useful if you want to take advantage of xscast's screenkeys-like functionality while using another program to handle recording or streaming.